### PR TITLE
Add spacing to product grid and the no results message

### DIFF
--- a/src/app/(shop)/search-results/page.tsx
+++ b/src/app/(shop)/search-results/page.tsx
@@ -41,9 +41,11 @@ export default function SearchResults() {
       <>
         <Header />
         {searchedProducts?.length === 0 && (
-          <p className="px-2">
-            Sorry, no products match your search. Please try something else!
-          </p>
+          <div className="h-[70vh] flex justify-center items-center">
+            <p className="px-2">
+              Sorry, no products match your search. Please try something else!
+            </p>
+          </div>
         )}
         {searchedProducts && <ProductGrid data={searchedProducts} />}
         <Footer />

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -22,7 +22,7 @@ export default function Header() {
   ];
 
   return (
-    <header className="flex flex-row justify-between  items-center text-center w-screen border border-black">
+    <header className="flex flex-row justify-between items-center text-center w-screen border border-black">
       <Link href={"/"} className="text-7xl bg-gray-custom p-5">
         JSJ
       </Link>

--- a/src/components/ProductGrid/ProductGrid.tsx
+++ b/src/components/ProductGrid/ProductGrid.tsx
@@ -10,17 +10,16 @@ interface ProductGridProps {
 export default function ProductGrid({ data }: ProductGridProps) {
   const products = data?.map((product) => (
     <Link href={`/product/${product.id}`} key={product.id}>
-      <section className="flex justify-center m-[2rem] h-[60vh]">
-        <div className="flex-col max-w-80 h-96">
-          <div className="grid justify-center pb-4">
-            <Image
-              src={product.image}
-              width={250}
-              height={250}
-              alt={product.title}
-              style={{ objectFit: "contain", height: "250px" }}
-            ></Image>
-          </div>
+      <section className="flex justify-center m-[2rem] ">
+        <div className="flex-col justify-center max-w-64 h-80 ">
+          <Image
+            src={product.image}
+            width={250}
+            height={250}
+            alt={product.title}
+            style={{ objectFit: "contain", maxHeight: "250px" }}
+            className="grid justify-center pb-4 h-52 sm:h-56 md:h-72 lg:h-96"
+          ></Image>
           <h2 className="font-semibold line-clamp-2">{product.title}</h2>
           <p>${product.price}</p>
           <p>
@@ -30,5 +29,9 @@ export default function ProductGrid({ data }: ProductGridProps) {
       </section>
     </Link>
   ));
-  return <div className="grid grid-cols-4 gap-8 p-5">{products}</div>;
+  return (
+    <div className="grid grid-cols-1 gap-0 p-0 sm:grid-cols-2 md:grid-cols-3 md:gap-5 lg:grid-cols-4 ">
+      {products}
+    </div>
+  );
 }

--- a/src/components/ProductGrid/ProductGrid.tsx
+++ b/src/components/ProductGrid/ProductGrid.tsx
@@ -10,7 +10,7 @@ interface ProductGridProps {
 export default function ProductGrid({ data }: ProductGridProps) {
   const products = data?.map((product) => (
     <Link href={`/product/${product.id}`} key={product.id}>
-      <section className="flex justify-center">
+      <section className="flex justify-center m-[2rem] h-[60vh]">
         <div className="flex-col max-w-80 h-96">
           <div className="grid justify-center pb-4">
             <Image
@@ -30,5 +30,5 @@ export default function ProductGrid({ data }: ProductGridProps) {
       </section>
     </Link>
   ));
-  return <div className="grid grid-cols-4 gap-8 p-5 h-[60vh]">{products}</div>;
+  return <div className="grid grid-cols-4 gap-8 p-5">{products}</div>;
 }


### PR DESCRIPTION
## What I did:
- Changed the height for the product grid so the footer will always be at the bottom of the page 
- Changed the spacing for the "no results" message so the footer will be at the bottom of the page
## Notes:

### Did this break anything?

- [x] No
- [ ]  Yes

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Cypress testing, all tests are passing


### Contributors to this pull request:
